### PR TITLE
Preserve Kind

### DIFF
--- a/src/FinalSpan.cs
+++ b/src/FinalSpan.cs
@@ -19,7 +19,7 @@ namespace moment.net
         {
             int m = _dt.Month;
             // only loop through the last seven days of the month
-            _dt = new DateTime(_dt.Year,_dt.Month, (DateTime.DaysInMonth(_dt.Year, _dt.Month)-7));
+            _dt = new DateTime(_dt.Year,_dt.Month, (DateTime.DaysInMonth(_dt.Year, _dt.Month)-7), 0, 0, 0, _dt.Kind);
             while (_dt.Month == m)
             {
                 if(_dt.DayOfWeek == _dow)
@@ -33,7 +33,7 @@ namespace moment.net
 
         public DateTime InYear()
         {
-            var dt = new DateTime(_dt.Year, 12, (DateTime.DaysInMonth(_dt.Year, 12) - 7));
+            var dt = new DateTime(_dt.Year, 12, (DateTime.DaysInMonth(_dt.Year, 12) - 7), 0, 0, 0, _dt.Kind);
             return new FinalSpan(dt, _dow).InMonth();
         }
     }

--- a/src/RelativeTime.cs
+++ b/src/RelativeTime.cs
@@ -146,19 +146,19 @@ namespace moment.net
             switch (timeAnchor)
             {
                 case DateTimeAnchor.Minute:
-                    return new DateTime(This.Year, This.Month, This.Day, This.Hour, This.Minute, 59, 999);
+                    return new DateTime(This.Year, This.Month, This.Day, This.Hour, This.Minute, 59, 999, This.Kind);
                 case DateTimeAnchor.Hour:
-                    return new DateTime(This.Year, This.Month, This.Day, This.Hour, 59, 59, 999);
+                    return new DateTime(This.Year, This.Month, This.Day, This.Hour, 59, 59, 999, This.Kind);
                 case DateTimeAnchor.Day:
-                    return new DateTime(This.Year, This.Month, This.Day, 23, 59, 59, 999);
+                    return new DateTime(This.Year, This.Month, This.Day, 23, 59, 59, 999, This.Kind);
                 case DateTimeAnchor.Week:
                     var tmp = This.LastDateInWeek(cultureInfo);
-                    return new DateTime(tmp.Year, tmp.Month, tmp.Day, 23, 59, 59, 999);
+                    return new DateTime(tmp.Year, tmp.Month, tmp.Day, 23, 59, 59, 999, This.Kind);
                 case DateTimeAnchor.Month:
                     var days = DateTime.DaysInMonth(This.Year, This.Month);
-                    return new DateTime(This.Year, This.Month, days, 23, 59, 59, 999);
+                    return new DateTime(This.Year, This.Month, days, 23, 59, 59, 999, This.Kind);
                 case DateTimeAnchor.Year:
-                    return new DateTime(This.Year, 12, DateTime.DaysInMonth(This.Year, 12), 23, 59, 59, 999);
+                    return new DateTime(This.Year, 12, DateTime.DaysInMonth(This.Year, 12), 23, 59, 59, 999, This.Kind);
                 default:
                     throw new ArgumentException();
             }

--- a/src/RelativeTime.cs
+++ b/src/RelativeTime.cs
@@ -105,18 +105,18 @@ namespace moment.net
             switch (timeAnchor)
             {
                 case DateTimeAnchor.Minute:
-                    return new DateTime(This.Year, This.Month, This.Day, This.Hour, This.Minute, 0, 0);
+                    return new DateTime(This.Year, This.Month, This.Day, This.Hour, This.Minute, 0, 0, This.Kind);
                 case DateTimeAnchor.Hour:
-                    return new DateTime(This.Year, This.Month, This.Day, This.Hour, 0, 0, 0);
+                    return new DateTime(This.Year, This.Month, This.Day, This.Hour, 0, 0, 0, This.Kind);
                 case DateTimeAnchor.Day:
-                    return new DateTime(This.Year, This.Month, This.Day,0,0,0,0);
+                    return new DateTime(This.Year, This.Month, This.Day,0,0,0,0, This.Kind);
                 case DateTimeAnchor.Week:
                     var tmp = This.FirstDateInWeek(cultureInfo);
-                    return new DateTime(tmp.Year, tmp.Month, tmp.Day, 0, 0, 0, 0);
+                    return new DateTime(tmp.Year, tmp.Month, tmp.Day, 0, 0, 0, 0, This.Kind);
                 case DateTimeAnchor.Month:
-                    return new DateTime(This.Year, This.Month, 1, 0, 0, 0, 0);
+                    return new DateTime(This.Year, This.Month, 1, 0, 0, 0, 0, This.Kind);
                 case DateTimeAnchor.Year:
-                    return new DateTime(This.Year, 1, 1, 0, 0, 0, 0);
+                    return new DateTime(This.Year, 1, 1, 0, 0, 0, 0, This.Kind);
                 default:
                     throw new ArgumentException();
             }

--- a/tests/EndOf.Tests.cs
+++ b/tests/EndOf.Tests.cs
@@ -7,48 +7,54 @@ namespace moment.net.Tests
 {
     public class EndOfTests
     {
-        string dateString = "5/1/2008 8:30:52 AM";
+        string dateString = "5/1/2008 8:30:52Z AM";
 
         [Test]
         public void EndOfMinuteTest()
         {
-            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
+            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
             date.EndOf(DateTimeAnchor.Minute).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("01/05/2008 08:30:59");
+            date.EndOf(DateTimeAnchor.Minute).Kind.ShouldBe(DateTimeKind.Utc);
         }
 
         [Test]
         public void EndOfHourTest()
         {
-            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
+            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
             date.EndOf(DateTimeAnchor.Hour).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("01/05/2008 08:59:59");
+            date.EndOf(DateTimeAnchor.Hour).Kind.ShouldBe(DateTimeKind.Utc);
         }
 
         [Test]
         public void EndOfDayTest()
         {
-            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
+            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
             date.EndOf(DateTimeAnchor.Day).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("01/05/2008 23:59:59");
+            date.EndOf(DateTimeAnchor.Day).Kind.ShouldBe(DateTimeKind.Utc);
         }
 
         [Test]
         public void EndOfWeekTest()
         {
-            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
+            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
             date.EndOf(DateTimeAnchor.Week).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("03/05/2008 23:59:59");
+            date.EndOf(DateTimeAnchor.Week).Kind.ShouldBe(DateTimeKind.Utc);
         }
 
         [Test]
         public void EndOfMonthTest()
         {
-            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
+            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
             date.EndOf(DateTimeAnchor.Month).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("31/05/2008 23:59:59");
+            date.EndOf(DateTimeAnchor.Month).Kind.ShouldBe(DateTimeKind.Utc);
         }
 
         [Test]
         public void EndOfYearTest()
         {
-            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
+            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
             date.EndOf(DateTimeAnchor.Year).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("31/12/2008 23:59:59");
+            date.EndOf(DateTimeAnchor.Year).Kind.ShouldBe(DateTimeKind.Utc);
         }
     }
 }

--- a/tests/Final.Test.cs
+++ b/tests/Final.Test.cs
@@ -7,20 +7,22 @@ namespace moment.net.Tests
 {
     public class Final
     {
-        string dateString = "5/1/2008 8:30:52 AM";
+        string dateString = "5/1/2008 8:30:52Z AM";
 
         [Test]
         public void FinalInMonthTest()
         {
-            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
+            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
             date.Final().Monday().InMonth().ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("26/05/2008 00:00:00");
+            date.Final().Monday().InMonth().Kind.ShouldBe(DateTimeKind.Utc);
         }
 
         [Test]
         public void FinalInYearTest()
         {
-            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
+            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
             date.Final().Sunday().InYear().ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("28/12/2008 00:00:00");
+            date.Final().Sunday().InYear().Kind.ShouldBe(DateTimeKind.Utc);
         }
     }
 }

--- a/tests/FirstLastDateInWeek.Tests.cs
+++ b/tests/FirstLastDateInWeek.Tests.cs
@@ -7,20 +7,22 @@ namespace moment.net.Tests
 {
     public class FirstLastDateInWeek
     {
-        string dateString = "5/1/2008 8:30:52 AM";
+        string dateString = "5/1/2008 8:30:52Z AM";
 
         [Test]
         public void FirstDateInWeekTest()
         {
-            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
+            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
             date.FirstDateInWeek().ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("27/04/2008 00:00:00");
+            date.FirstDateInWeek().Kind.ShouldBe(DateTimeKind.Utc);
         }
 
         [Test]
         public void LastDateInWeekTest()
         {
-            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
+            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
             date.LastDateInWeek().ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("03/05/2008 00:00:00");
+            date.LastDateInWeek().Kind.ShouldBe(DateTimeKind.Utc);
         }
 
     }

--- a/tests/Last.Tests.cs
+++ b/tests/Last.Tests.cs
@@ -12,14 +12,14 @@ namespace moment.net.Tests
         public void LastDayOfWeekTest()
         {
             DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
-            date.Last(DayOfWeek.Thursday).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("24/04/2008 08:30:52"); 
+            date.Last(DayOfWeek.Thursday).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("24/04/2008 08:30:52");
         }
 
         [Test]
         public void LastNthDayOfWeekTest()
         {
             DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
-            date.Last(DayOfWeek.Thursday,3).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("10/04/2008 08:30:52"); 
+            date.Last(DayOfWeek.Thursday,3).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("10/04/2008 08:30:52");
         }
     }
 }

--- a/tests/Last.Tests.cs
+++ b/tests/Last.Tests.cs
@@ -6,20 +6,22 @@ namespace moment.net.Tests
 {
     public class Last
     {
-        string dateString = "5/1/2008 8:30:52 AM";
+        string dateString = "5/1/2008 8:30:52Z AM";
 
         [Test]
         public void LastDayOfWeekTest()
         {
-            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
+            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
             date.Last(DayOfWeek.Thursday).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("24/04/2008 08:30:52");
+            date.Last(DayOfWeek.Thursday).Kind.ShouldBe(DateTimeKind.Utc);
         }
 
         [Test]
         public void LastNthDayOfWeekTest()
         {
-            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
-            date.Last(DayOfWeek.Thursday,3).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("10/04/2008 08:30:52");
+            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
+            date.Last(DayOfWeek.Thursday, 3).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("10/04/2008 08:30:52");
+            date.Last(DayOfWeek.Thursday, 3).Kind.ShouldBe(DateTimeKind.Utc);
         }
     }
 }

--- a/tests/Next.Tests.cs
+++ b/tests/Next.Tests.cs
@@ -7,20 +7,22 @@ namespace moment.net.Tests
 {
     public class Next
     {
-        string dateString = "5/1/2008 8:30:52 AM";
+        string dateString = "5/1/2008 8:30:52Z AM";
 
         [Test]
         public void NextDayOfWeekTest()
         {
-            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
+            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
             date.Next(DayOfWeek.Thursday).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("08/05/2008 08:30:52");
+            date.Next(DayOfWeek.Thursday).Kind.ShouldBe(DateTimeKind.Utc);
         }
 
         [Test]
         public void NextNthDayOfWeekTest()
         {
-            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
-            date.Next(DayOfWeek.Thursday,3).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("22/05/2008 08:30:52");
+            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
+            date.Next(DayOfWeek.Thursday, 3).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("22/05/2008 08:30:52");
+            date.Next(DayOfWeek.Thursday, 3).Kind.ShouldBe(DateTimeKind.Utc);
         }
     }
 }

--- a/tests/StartOf.Tests.cs
+++ b/tests/StartOf.Tests.cs
@@ -20,7 +20,7 @@ namespace moment.net.Tests
         public void StartOfHourTest()
         {
             DateTime date = DateTime.Parse(dateString,System.Globalization.CultureInfo.InvariantCulture);
-            date.StartOf(DateTimeAnchor.Hour).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("01/05/2008 08:00:00"); 
+            date.StartOf(DateTimeAnchor.Hour).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("01/05/2008 08:00:00");
         }
 
         [Test]

--- a/tests/StartOf.Tests.cs
+++ b/tests/StartOf.Tests.cs
@@ -7,49 +7,54 @@ namespace moment.net.Tests
 {
     public class StartOfTests
     {
-        string dateString = "5/1/2008 8:30:52 AM";
+        string dateString = "5/1/2008 8:30:52Z AM";
 
         [Test]
         public void StartOfMinuteTest()
         {
-            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
+            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
             date.StartOf(DateTimeAnchor.Minute).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("01/05/2008 08:30:00");
+            date.StartOf(DateTimeAnchor.Minute).Kind.ShouldBe(DateTimeKind.Utc);
         }
 
         [Test]
         public void StartOfHourTest()
         {
-            DateTime date = DateTime.Parse(dateString,System.Globalization.CultureInfo.InvariantCulture);
+            DateTime date = DateTime.Parse(dateString,System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
             date.StartOf(DateTimeAnchor.Hour).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("01/05/2008 08:00:00");
+            date.StartOf(DateTimeAnchor.Hour).Kind.ShouldBe(DateTimeKind.Utc);
         }
 
         [Test]
         public void StartOfDayTest()
         {
-            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
+            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
             date.StartOf(DateTimeAnchor.Day).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("01/05/2008 00:00:00");
+            date.StartOf(DateTimeAnchor.Day).Kind.ShouldBe(DateTimeKind.Utc);
         }
 
         [Test]
         public void StartOfWeekTest()
         {
-
-            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
+            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
             date.StartOf(DateTimeAnchor.Week).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("27/04/2008 00:00:00");
+            date.StartOf(DateTimeAnchor.Week).Kind.ShouldBe(DateTimeKind.Utc);
         }
 
         [Test]
         public void StartOfMonthTest()
         {
-            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
+            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
             date.StartOf(DateTimeAnchor.Month).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("01/05/2008 00:00:00");
+            date.StartOf(DateTimeAnchor.Month).Kind.ShouldBe(DateTimeKind.Utc);
         }
 
         [Test]
         public void StartOfYearTest()
         {
-            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture);
+            DateTime date = DateTime.Parse(dateString, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
             date.StartOf(DateTimeAnchor.Year).ToString("dd/MM/yyyy HH:mm:ss").ShouldBe("01/01/2008 00:00:00");
+            date.StartOf(DateTimeAnchor.Year).Kind.ShouldBe(DateTimeKind.Utc);
         }
     }
 }

--- a/tests/UnixTime.Tests.cs
+++ b/tests/UnixTime.Tests.cs
@@ -14,7 +14,7 @@ namespace moment.net.Tests
             var millisecondsElapsed = dateTime.UnixTimestampInMilliseconds();
             millisecondsElapsed.ShouldBe(365.0 * 24 * 60 * 60 * 1000);
         }
-        
+
         [Test]
         public void UnixTimeInSecondsOneUtcYearFromEpoch()
         {


### PR DESCRIPTION
This is to close #13.

It makes sure that Kind information makes it through `DateTime` transforms. Some transforms did preserve, so only their tests were updated.

Feel free to point out anything I might have missed.

Oh, my IDE highlights trailing whitespaces, so I removed them when I saw them too.